### PR TITLE
Use Granite style classes, misc cleanup

### DIFF
--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -24,47 +24,35 @@ public class Widgets.AppEntry : Gtk.ListBoxRow {
 
     public Backend.App app { get; construct; }
 
-    private Gtk.Grid grid;
-
-    private Gtk.Image image;
-    private Gtk.Label title_label;
-    private Gtk.Label description_label;
-
     public AppEntry (Backend.App app) {
         Object (app: app);
-
-        build_ui ();
-        connect_signals ();
     }
 
-    private void build_ui () {
-        grid = new Gtk.Grid ();
-        grid.margin = 6;
-        grid.column_spacing = 6;
-
-        image = new Gtk.Image.from_gicon (app.app_info.get_icon (), Gtk.IconSize.DND);
+    construct {
+        var image = new Gtk.Image.from_gicon (app.app_info.get_icon (), Gtk.IconSize.DND);
         image.pixel_size = 32;
 
-        title_label = new Gtk.Label (app.app_info.get_display_name ());
-        title_label.get_style_context ().add_class ("h3");
+        var title_label = new Gtk.Label (app.app_info.get_display_name ());
+        title_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
         title_label.ellipsize = Pango.EllipsizeMode.END;
-        ((Gtk.Misc) title_label).xalign = 0;
+        title_label.xalign = 0;
         title_label.valign = Gtk.Align.END;
 
-        description_label = new Gtk.Label (get_permissions_string (app));
+        var description_label = new Gtk.Label (get_permissions_string (app));
         description_label.use_markup = true;
         description_label.ellipsize = Pango.EllipsizeMode.END;
-        ((Gtk.Misc) description_label).xalign = 0;
+        description_label.xalign = 0;
         description_label.valign = Gtk.Align.START;
 
+        var grid = new Gtk.Grid ();
+        grid.margin = 6;
+        grid.column_spacing = 6;
         grid.attach (image, 0, 0, 1, 2);
         grid.attach (title_label, 1, 0, 1, 1);
         grid.attach (description_label, 1, 1, 1, 1);
 
         this.add (grid);
-    }
 
-    private void connect_signals () {
         app.settings.changed.connect (() => {
             description_label.set_markup (get_permissions_string (app));
         });

--- a/src/Widgets/Footer.vala
+++ b/src/Widgets/Footer.vala
@@ -18,30 +18,19 @@
  */
 
 public class Widgets.Footer : Gtk.ActionBar {
-    private Gtk.Label do_not_disturb_label;
-    private Gtk.Switch do_not_disturb_switch;
-
     construct {
-        build_ui ();
-        create_bindings ();
-    }
+        get_style_context ().add_class (Gtk.STYLE_CLASS_INLINE_TOOLBAR);
 
-    private void build_ui () {
-        this.get_style_context ().add_class (Gtk.STYLE_CLASS_INLINE_TOOLBAR);
-
-        do_not_disturb_label = new Gtk.Label (_("Do Not Disturb"));
-        do_not_disturb_label.get_style_context ().add_class ("h4");
+        var do_not_disturb_label = new Granite.HeaderLabel (_("Do Not Disturb"));
         do_not_disturb_label.margin_start = 6;
 
-        do_not_disturb_switch = new Gtk.Switch ();
+        var do_not_disturb_switch = new Gtk.Switch ();
         do_not_disturb_switch.margin = 12;
         do_not_disturb_switch.margin_end = 6;
 
-        this.pack_start (do_not_disturb_label);
-        this.pack_end (do_not_disturb_switch);
-    }
+        pack_start (do_not_disturb_label);
+        pack_end (do_not_disturb_switch);
 
-    private void create_bindings () {
         Backend.NotifyManager.get_default ().bind_property ("do-not-disturb",
                                                             do_not_disturb_switch,
                                                             "state",

--- a/src/Widgets/SettingsHeader.vala
+++ b/src/Widgets/SettingsHeader.vala
@@ -22,22 +22,6 @@ public class Widgets.SettingsHeader : Gtk.Grid {
     private Gtk.Label app_label;
 
     construct {
-        build_ui ();
-    }
-
-    public void set_title (string title) {
-        app_label.set_label (title);
-        app_label.get_style_context ().add_class ("h2");
-    }
-
-    public void set_icon (Icon icon) {
-        app_image.set_from_gicon (icon, Gtk.IconSize.DIALOG);
-        app_image.set_pixel_size (48);
-    }
-
-    private void build_ui () {
-        this.column_spacing = 12;
-
         app_image = new Gtk.Image ();
 
         app_label = new Gtk.Label (null);
@@ -45,7 +29,18 @@ public class Widgets.SettingsHeader : Gtk.Grid {
         app_label.halign = Gtk.Align.START;
         app_label.hexpand = true;
 
-        this.attach (app_image, 0, 0, 1, 1);
-        this.attach (app_label, 1, 0, 1, 1);
+        column_spacing = 12;
+        attach (app_image, 0, 0, 1, 1);
+        attach (app_label, 1, 0, 1, 1);
+    }
+
+    public void set_title (string title) {
+        app_label.set_label (title);
+        app_label.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
+    }
+
+    public void set_icon (Icon icon) {
+        app_image.set_from_gicon (icon, Gtk.IconSize.DIALOG);
+        app_image.set_pixel_size (48);
     }
 }

--- a/src/Widgets/SettingsOption.vala
+++ b/src/Widgets/SettingsOption.vala
@@ -47,7 +47,7 @@ public class Widgets.SettingsOption : Gtk.Grid {
         image.hexpand = false;
 
         title_label = new Gtk.Label (title);
-        title_label.get_style_context ().add_class ("h3");
+        title_label.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
         title_label.halign = Gtk.Align.START;
         title_label.valign = Gtk.Align.END;
         title_label.hexpand = true;
@@ -59,7 +59,7 @@ public class Widgets.SettingsOption : Gtk.Grid {
         widget.vexpand = false;
 
         description_label = new Gtk.Label (description);
-        ((Gtk.Misc) description_label).xalign = 0;
+        description_label.xalign = 0;
         description_label.valign = Gtk.Align.START;
         description_label.hexpand = true;
         description_label.vexpand = false;


### PR DESCRIPTION
Use latest stuff from Granite and do a little cleanup while we're here

AppEntry:
* Use Granite.STYLE_CLASS constant
* Remove unnecessary cast to Gtk.Misc
* Reduce variable scope
* GObject-style

Footer:
* Use Granite.HeaderLabel
* Simplify unnecessary methods and reduce variable scope

SettingsHeader:
* Simplify
* Use Granite.STYLE_CLASS constant

SettingsOptions:
* Use Granite.STYLE_CLASS constant
* Remove unnecessary cast to Gtk.Misc