### PR TITLE
Header icons: Standardize sizing

### DIFF
--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -32,7 +32,6 @@ public class Widgets.AppEntry : Gtk.ListBoxRow {
         var image = new Gtk.Image.from_gicon (app.app_info.get_icon (), Gtk.IconSize.DND) {
             pixel_size = 32
         };
-        image.get_style_context ().add_class ("icon-dropshadow");
 
         var title_label = new Gtk.Label (app.app_info.get_display_name ()) {
             ellipsize = Pango.EllipsizeMode.END,

--- a/src/Widgets/AppEntry.vala
+++ b/src/Widgets/AppEntry.vala
@@ -32,6 +32,7 @@ public class Widgets.AppEntry : Gtk.ListBoxRow {
         var image = new Gtk.Image.from_gicon (app.app_info.get_icon (), Gtk.IconSize.DND) {
             pixel_size = 32
         };
+        image.get_style_context ().add_class ("icon-dropshadow");
 
         var title_label = new Gtk.Label (app.app_info.get_display_name ()) {
             ellipsize = Pango.EllipsizeMode.END,

--- a/src/Widgets/AppSettingsView.vala
+++ b/src/Widgets/AppSettingsView.vala
@@ -27,8 +27,9 @@ public class Widgets.AppSettingsView : Gtk.Grid {
 
     construct {
         app_image = new Gtk.Image () {
-            pixel_size = 48
+            pixel_size = 64
         };
+        app_image.get_style_context ().add_class ("icon-dropshadow");
 
         app_label = new Gtk.Label (null) {
             use_markup = true,

--- a/src/Widgets/AppSettingsView.vala
+++ b/src/Widgets/AppSettingsView.vala
@@ -29,7 +29,6 @@ public class Widgets.AppSettingsView : Gtk.Grid {
         app_image = new Gtk.Image () {
             pixel_size = 64
         };
-        app_image.get_style_context ().add_class ("icon-dropshadow");
 
         app_label = new Gtk.Label (null) {
             use_markup = true,


### PR DESCRIPTION
Looks like this in action:
![a (2)](https://user-images.githubusercontent.com/4886639/104514374-e2682780-55cf-11eb-917d-828ac88ae15f.png)
