### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -23,6 +23,15 @@ plug_resources = gnome.compile_resources(
     source_dir: 'data'
 )
 
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name() + '-plug')
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 subdir('data')
 subdir('src')
 subdir('po')

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -38,6 +38,9 @@ public class NotificationsPlug : Switchboard.Plug {
     private Granite.Widgets.AlertView alert_view;
 
     public NotificationsPlug () {
+        GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+
         var settings = new Gee.TreeMap<string, string?> (null, null);
         settings.set ("notifications", null);
         Object (category: Category.PERSONAL,

--- a/src/meson.build
+++ b/src/meson.build
@@ -15,6 +15,7 @@ switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define
 shared_module(
     meson.project_name(),
     plug_files,
+    config_file,
     plug_resources,
     dependencies: [
         dependency('glib-2.0'),


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)