### PR TITLE
AppSettingsView: don't block settings when DND is active

### DIFF
--- a/data/SettingsOption.css
+++ b/data/SettingsOption.css
@@ -17,6 +17,13 @@
 * Boston, MA 02110-1301 USA.
 */
 
+settingspage.notifications infobar revealer > box {
+    background-color: mix(@GRAPE_500, @GRAPE_700, 0.5);
+    background-image: -gtk-icontheme("notification-disabled-symbolic");
+    color: white;
+    margin-bottom: 2em;
+}
+
 settingspage.notifications .card {
     background-position: center;
     background-repeat: no-repeat;
@@ -24,6 +31,7 @@ settingspage.notifications .card {
     min-width: 112px;
     min-height: 80px;
     margin-top: 1em;
+    margin-bottom: 2em;
 }
 
 settingspage.notifications .card.bubbles {

--- a/src/Widgets/AppSettingsView.vala
+++ b/src/Widgets/AppSettingsView.vala
@@ -30,6 +30,18 @@ public class Widgets.AppSettingsView : Switchboard.SettingsPage {
     }
 
     construct {
+        var dnd_header = new Granite.HeaderLabel (_("Do Not Disturb is active")) {
+            halign = FILL,
+            hexpand = true,
+            secondary_text = _("Bubbles will be hidden and sounds will be silenced. System notifications, such as volume and display brightness, will be unaffected.")
+        };
+
+        var dnd_infobar = new Gtk.InfoBar () {
+            message_type = INFO
+        };
+        dnd_infobar.add_child (dnd_header);
+        dnd_infobar.add_css_class (Granite.STYLE_CLASS_FRAME);
+
         bubbles_option = new SettingsOption (
             "bubbles",
             _("Bubbles"),
@@ -48,7 +60,8 @@ public class Widgets.AppSettingsView : Switchboard.SettingsPage {
             _("Show missed notifications in Notification Center.")
         );
 
-        var box = new Gtk.Box (VERTICAL, 24);
+        var box = new Gtk.Box (VERTICAL, 0);
+        box.append (dnd_infobar);
         box.append (bubbles_option);
         box.append (sound_option);
         box.append (remember_option);
@@ -62,6 +75,8 @@ public class Widgets.AppSettingsView : Switchboard.SettingsPage {
             remove_bindings ();
             update_selected_app ();
         });
+
+        NotificationsPlug.notify_settings.bind ("do-not-disturb", dnd_infobar, "revealed", GET);
     }
 
     private void remove_bindings () {

--- a/src/Widgets/MainView.vala
+++ b/src/Widgets/MainView.vala
@@ -19,7 +19,6 @@
 
 public class Widgets.MainView : Gtk.Widget {
     private Gtk.Paned main_widget;
-    private Gtk.Stack stack;
 
     static construct {
         set_layout_manager_type (typeof (Gtk.BinLayout));
@@ -30,40 +29,15 @@ public class Widgets.MainView : Gtk.Widget {
 
         var app_settings_view = new AppSettingsView ();
 
-        var description = _("While in Do Not Disturb mode, notifications and alerts will be hidden and notification sounds will be silenced.");
-        description += "\n\n";
-        description += _("System notifications, such as volume and display brightness, will be unaffected.");
-
-        var alert_view = new Granite.Placeholder (_("Do Not Disturb is active")) {
-            description = description,
-            icon = new ThemedIcon ("notification-disabled")
-        };
-
-        stack = new Gtk.Stack ();
-        stack.add_named (app_settings_view, "app-settings-view");
-        stack.add_named (alert_view, "alert-view");
-
         main_widget = new Gtk.Paned (Gtk.Orientation.HORIZONTAL) {
             start_child = sidebar,
-            end_child = stack,
+            end_child = app_settings_view,
             resize_start_child = false,
             shrink_start_child = false,
             shrink_end_child = false,
             position = 240
         };
         main_widget.set_parent (this);
-
-        update_view ();
-
-        NotificationsPlug.notify_settings.changed["do-not-disturb"].connect (update_view);
-    }
-
-    private void update_view () {
-        if (NotificationsPlug.notify_settings.get_boolean ("do-not-disturb")) {
-            stack.visible_child_name = "alert-view";
-        } else {
-            stack.visible_child_name = "app-settings-view";
-        }
     }
 
     ~MainView () {

--- a/src/Widgets/Sidebar.vala
+++ b/src/Widgets/Sidebar.vala
@@ -78,15 +78,8 @@ public class Widgets.Sidebar : Gtk.Box {
 
         NotificationsPlug.notify_settings.bind (
             "do-not-disturb",
-            app_list,
-            "sensitive",
-            SettingsBindFlags.INVERT_BOOLEAN
-        );
-
-        NotificationsPlug.notify_settings.bind (
-            "do-not-disturb",
             do_not_disturb_switch,
-            "state",
+            "active",
             SettingsBindFlags.DEFAULT
         );
 


### PR DESCRIPTION
Fixes #91
Prevents blocking settings when DND is active

![Screenshot from 2024-03-09 13 32 51](https://github.com/elementary/switchboard-plug-notifications/assets/7277719/8441fed0-2f92-46e0-afd8-f4fff36fec91)

I know InfoBar is deprecated but we use it a lot so I think we probably will need a Granite replacement so I'm using it assuming we'll fix all infobars at once later.