### PR TITLE
Fix initial switch position

### DIFF
--- a/src/Widgets/SettingsOption.vala
+++ b/src/Widgets/SettingsOption.vala
@@ -45,6 +45,7 @@ public class Widgets.SettingsOption : Gtk.Grid {
         widget = new Gtk.Switch () {
             valign = START
         };
+        widget.bind_property ("state", widget, "active", SYNC_CREATE | BIDIRECTIONAL);
 
         var header_label = new Granite.HeaderLabel (title) {
             hexpand = true,


### PR DESCRIPTION
Currently when launching the switches are in the wrong position compared to their state for options that are toggled on.